### PR TITLE
Allow "return ref array[index]" on noncopyable types

### DIFF
--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Conversion/Source/Class2.csx
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Conversion/Source/Class2.csx
@@ -16,7 +16,7 @@ struct Collection<T> : IEnumerable<T>
         private T[] _data;
         private int _index;
         public T Current { get { return _data[_index]; } }
-        public Enumerator(T[] data) => (_data = data; _index = -1);
+        public Enumerator(T[] data) { _data = data; _index = -1; }
         public bool MoveNext() => (++_index >= _data.Length);
     }
 

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Diagnostic/Results.json
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Diagnostic/Results.json
@@ -2,7 +2,7 @@
   {
     "id": "NoCopy05",
     "sevirity": "Error",
-    "line": 33,
+    "line": 34,
     "column": 40,
     "path": "Class1.csx",
     "message-args": [ "Counter" ]
@@ -10,7 +10,7 @@
   {
     "id": "NoCopy05",
     "sevirity": "Error",
-    "line": 34,
+    "line": 35,
     "column": 46,
     "path": "Class1.csx",
     "message-args": [ "Counter" ]
@@ -18,7 +18,7 @@
   {
     "id": "NoCopy05",
     "sevirity": "Error",
-    "line": 39,
+    "line": 40,
     "column": 22,
     "path": "Class1.csx",
     "message-args": [ "Counter" ]
@@ -26,9 +26,9 @@
   {
     "id": "NoCopy05",
     "sevirity": "Error",
-    "line": 53,
+    "line": 54,
     "column": 53,
     "path": "Class1.csx",
     "message-args": [ "Counter" ]
-  }
+  },
 ]

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
@@ -30,7 +30,7 @@ struct Counter
 class Program
 {
     static Counter _c = new Counter();
-    static Counter _ca = new Counter[1];
+    static Counter[] _ca = new Counter[1];
     public static Counter Create1() => _c; // ❌
     public static Counter Create2() { return _c; } // ❌
 
@@ -54,10 +54,10 @@ class Program
         var c5 = Enumerable.Range(0, 5).Select(_ => _c); // ❌
 
         var r = ref Ref();
-        var v = Ref(); // ❌
+        var v = Ref();
         
         var r = ref ArrayRef();
-        var v = ArrayRef(); // ❌
+        var v = ArrayRef();
     }
 
     public static ref Counter Ref() { return ref _c; }

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
@@ -30,6 +30,7 @@ struct Counter
 class Program
 {
     static Counter _c = new Counter();
+    static Counter _ca = new Counter[1];
     public static Counter Create1() => _c; // ❌
     public static Counter Create2() { return _c; } // ❌
 
@@ -53,8 +54,12 @@ class Program
         var c5 = Enumerable.Range(0, 5).Select(_ => _c); // ❌
 
         var r = ref Ref();
-        var v = Ref();
+        var v = Ref(); // ❌
+        
+        var r = ref ArrayRef();
+        var v = ArrayRef(); // ❌
     }
 
     public static ref Counter Ref() { return ref _c; }
+    public static ref Counter ArrayRef() { return ref _ca[0]; }
 }

--- a/src/NonCopyable/NonCopyable/TypeExtensions.cs
+++ b/src/NonCopyable/NonCopyable/TypeExtensions.cs
@@ -71,7 +71,7 @@ namespace NonCopyable
                 if (operandKind == OperationKind.DefaultValue || operandKind == OperationKind.Invalid) return true;
             }
 
-            if (k == OperationKind.LocalReference || k == OperationKind.FieldReference || k == OperationKind.PropertyReference)
+            if (k == OperationKind.LocalReference || k == OperationKind.FieldReference || k == OperationKind.PropertyReference || k == OperationKind.ArrayElementReference)
             {
                 //need help: how to get ref-ness from IOperation?
                 var parent = op.Syntax.Parent.Kind();


### PR DESCRIPTION
Previously, this code would produce an analysis error:

```
NonCopyable[] items = new NonCopyable[] { ... };
ref NonCopyable Get(int i) { return ref items[i]; } // ERROR
```

Even though there is no copy being performed here. This PR fixes this problem.

PS: Thanks for accepting my last one!