### PR TITLE
Fixed false positive on conversion operators with in argument #14

### DIFF
--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Conversion/Diagnostic/Results.json
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Conversion/Diagnostic/Results.json
@@ -82,6 +82,22 @@
   {
     "id": "NoCopy06",
     "sevirity": "Error",
+    "line": 44,
+    "column": 41,
+    "path": "Class1.csx",
+    "message-args": [ "Counter" ]
+  },
+  {
+    "id": "NoCopy06",
+    "sevirity": "Error",
+    "line": 46,
+    "column": 46,
+    "path": "Class1.csx",
+    "message-args": [ "Counter" ]
+  },
+  {
+    "id": "NoCopy06",
+    "sevirity": "Error",
     "line": 40,
     "column": 43,
     "path": "Class2.csx",

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Conversion/Source/Class1.csx
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Conversion/Source/Class1.csx
@@ -39,5 +39,27 @@ class Program
         var s = "" + c; // ❌
 
         IDisposable d = c; // ❌
+
+        ConvertibleImplicitFromRef ir = c; // OK
+        ConvertibleImplicitFromVal iv = c; // ❌
+        var er = (ConvertibleExplicitFromRef)c; // OK
+        var ev = (ConvertibleExplicitFromVal)c; // ❌
     }
+}
+
+struct ConvertibleImplicitFromRef
+{
+    public static implicit operator ConvertibleImplicitFromRef(in Counter x) => default;
+}
+struct ConvertibleImplicitFromVal
+{
+    public static implicit operator ConvertibleImplicitFromVal(Counter x) => default;
+}
+struct ConvertibleExplicitFromRef
+{
+    public static explicit operator ConvertibleExplicitFromRef(in Counter x) => default;
+}
+struct ConvertibleExplicitFromVal
+{
+    public static explicit operator ConvertibleExplicitFromVal(Counter x) => default;
 }

--- a/src/NonCopyable/NonCopyable/NonCopyableAnalyzer.cs
+++ b/src/NonCopyable/NonCopyable/NonCopyableAnalyzer.cs
@@ -73,6 +73,12 @@ namespace NonCopyable
                     var t = v.Type;
                     if (!t.IsNonCopyable()) return;
 
+                    if (op.OperatorMethod != null && op.OperatorMethod.Parameters.Length == 1)
+                    {
+                        var parameter = op.OperatorMethod.Parameters[0];
+                        if (parameter.RefKind != RefKind.None) return;
+                    }
+
                     if (op.Parent is IForEachLoopOperation &&
                         op == ((IForEachLoopOperation)op.Parent).Collection &&
                         op.Conversion.IsIdentity)


### PR DESCRIPTION
When conversion operator has an associated method with 1 argument, check if that argument is passed by reference.