### PR TITLE
Upstreaming a few upgrades

### DIFF
--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/ObjectInitializer/Diagnostic/Results.json
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/ObjectInitializer/Diagnostic/Results.json
@@ -1,6 +1,6 @@
 ﻿[
   {
-    "id": "NoCopy02",
+    "id": "NoCopy04",
     "sevirity": "Error",
     "line": 29,
     "column": 13,
@@ -8,7 +8,7 @@
     "message-args": [ "Counter" ]
   },
   {
-    "id": "NoCopy02",
+    "id": "NoCopy04",
     "sevirity": "Error",
     "line": 35,
     "column": 15,

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/ReadOnly/Diagnostic/Results.json
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/ReadOnly/Diagnostic/Results.json
@@ -35,7 +35,7 @@
     "id": "NoCopy12",
     "sevirity": "Error",
     "line": 49,
-    "column": 20,
+    "column": 23,
     "path": "Class1.csx",
     "message-args": [ "Counter" ]
   },

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/ReadOnly/Source/Class1.csx
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/ReadOnly/Source/Class1.csx
@@ -46,7 +46,7 @@ class Program
         var v4 = ro.Value; // ❌
         ro.M(); // ❌
 
-        Action a = c.M; // ❌
+        Func<int> a = c.M; // ❌
     }
 
     static void MIn(in Counter ro)

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Diagnostic/Results.json
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Diagnostic/Results.json
@@ -31,4 +31,12 @@
     "path": "Class1.csx",
     "message-args": [ "Counter" ]
   },
+  {
+    "id": "NoCopy05",
+    "sevirity": "Error",
+    "line": 59,
+    "column": 34,
+    "path": "Class1.csx",
+    "message-args": [ "Counter" ]
+  }
 ]

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
@@ -62,4 +62,5 @@ class Program
 
     public static ref Counter Ref() { return ref _c; }
     public static ref Counter ArrayRef() { return ref _ca[0]; }
+    public static Counter CreateCond() => true ? new Counter() : default;
 }

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
@@ -63,4 +63,6 @@ class Program
     public static ref Counter Ref() { return ref _c; }
     public static ref Counter ArrayRef() { return ref _ca[0]; }
     public static Counter CreateCond() => true ? new Counter() : default;
+    static readonly delegate* unmanaged<Counter> pointerBasedFactory;
+    public static Counter CreatePointerBasedFactory() => pointerBasedFactory();
 }

--- a/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
+++ b/src/NonCopyable/NonCopyable.Test/DataSource/NonCopyable/Return/Source/Class1.csx
@@ -9,7 +9,7 @@ using System.Diagnostics;
 internal class NonCopyableAttribute : Attribute { }
 
 [NonCopyable]
-struct Counter
+partial struct Counter
 {
     private int _i;
     public Counter(int i) => _i = i;
@@ -53,11 +53,25 @@ class Program
         var c4 = Enumerable.Range(0, 5).Select(_ => new Counter());
         var c5 = Enumerable.Range(0, 5).Select(_ => _c); // ❌
 
+        void NestedCapturedReturn()
+        {
+            var tmp = new Counter();
+            Counter Capture() => tmp; // ❌
+        }
+
+        Counter ReturnTempVar()
+        {
+            var result = new Counter();
+            return result;
+        }
+
         var r = ref Ref();
         var v = Ref();
         
         var r = ref ArrayRef();
         var v = ArrayRef();
+
+        var fromTV = ReturnTempVar();
     }
 
     public static ref Counter Ref() { return ref _c; }
@@ -65,4 +79,9 @@ class Program
     public static Counter CreateCond() => true ? new Counter() : default;
     static readonly delegate* unmanaged<Counter> pointerBasedFactory;
     public static Counter CreatePointerBasedFactory() => pointerBasedFactory();
+}
+
+partial struct Counter
+{
+    public void Dispose() { }
 }

--- a/src/NonCopyable/NonCopyable.Test/NonCopyable.Test.csproj
+++ b/src/NonCopyable/NonCopyable.Test/NonCopyable.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/NonCopyable/NonCopyable.Test/NonCopyable.Test.csproj
+++ b/src/NonCopyable/NonCopyable.Test/NonCopyable.Test.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/NonCopyable/NonCopyable.Vsix/source.extension.vsixmanifest
+++ b/src/NonCopyable/NonCopyable.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" ?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="NonCopyable.1dd1f7a7-7947-4aa7-84c7-29edee95a0fa" Version="0.2" Language="en-US" Publisher="Nobuyuki Iwanaga"/>
+        <Identity Id="NonCopyable.1dd1f7a7-7947-4aa7-84c7-29edee95a0fa" Version="0.3" Language="en-US" Publisher="Nobuyuki Iwanaga"/>
         <DisplayName>NonCopyable</DisplayName>
         <Description xml:space="preserve">An analyzer for Non-Copyable structs.</Description>
         <License>LICENSE</License>

--- a/src/NonCopyable/NonCopyable/NonCopyable.csproj
+++ b/src/NonCopyable/NonCopyable/NonCopyable.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -21,7 +21,7 @@
   </PropertyGroup>
    
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/NonCopyable/NonCopyable/NonCopyable.csproj
+++ b/src/NonCopyable/NonCopyable/NonCopyable.csproj
@@ -15,7 +15,8 @@
     <PackageProjectUrl>https://github.com/ufcpp/NonCopyableAnalyzer</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Analyzer for Non-copyable struct</Description>
-    <PackageReleaseNotes>Fixed false positive on conversion operators with in argument.</PackageReleaseNotes>
+    <PackageReleaseNotes>Support for C# 9 unmanaged function pointers.
+Allow usage of non-copyable in conditional expressions (? :).</PackageReleaseNotes>
     <PackageTags>NonCopyable, analyzers</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>

--- a/src/NonCopyable/NonCopyable/NonCopyable.csproj
+++ b/src/NonCopyable/NonCopyable/NonCopyable.csproj
@@ -9,7 +9,7 @@
   
   <PropertyGroup>
     <PackageId>NonCopyableAnalyzer</PackageId>
-    <PackageVersion>0.6.0</PackageVersion>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Nobuyuki Iwanaga</Authors>
     <PackageLicenseUrl>https://github.com/ufcpp/NonCopyableAnalyzer/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ufcpp/NonCopyableAnalyzer</PackageProjectUrl>

--- a/src/NonCopyable/NonCopyable/NonCopyable.csproj
+++ b/src/NonCopyable/NonCopyable/NonCopyable.csproj
@@ -16,7 +16,8 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Analyzer for Non-copyable struct</Description>
     <PackageReleaseNotes>Support for C# 9 unmanaged function pointers.
-Allow usage of non-copyable in conditional expressions (? :).</PackageReleaseNotes>
+Allow usage of non-copyable in conditional expressions (? :).
+Treat return statement as having move semantics for locals and parameters.</PackageReleaseNotes>
     <PackageTags>NonCopyable, analyzers</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>

--- a/src/NonCopyable/NonCopyable/NonCopyable.csproj
+++ b/src/NonCopyable/NonCopyable/NonCopyable.csproj
@@ -22,7 +22,7 @@ Allow usage of non-copyable in conditional expressions (? :).</PackageReleaseNot
   </PropertyGroup>
    
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/NonCopyable/NonCopyable/TypeExtensions.cs
+++ b/src/NonCopyable/NonCopyable/TypeExtensions.cs
@@ -87,10 +87,15 @@ namespace NonCopyable
             return k == OperationKind.ObjectCreation
                 || k == OperationKind.DefaultValue
                 || k == OperationKind.Literal
-                || k == OperationKind.Invocation;
+                || k == OperationKind.Invocation
+                // workaround for https://github.com/dotnet/roslyn/issues/49751
+                || !IsValid(k) && op.Syntax is InvocationExpressionSyntax;
 
             //todo: should return value be OK?
             //todo: move semantics
         }
+
+        static bool IsValid(OperationKind kind)
+            => kind != OperationKind.None && kind != OperationKind.Invalid;
     }
 }

--- a/src/NonCopyable/NonCopyable/TypeExtensions.cs
+++ b/src/NonCopyable/NonCopyable/TypeExtensions.cs
@@ -78,6 +78,12 @@ namespace NonCopyable
                 if (parent == SyntaxKind.RefExpression) return true;
             }
 
+            if (k == OperationKind.Conditional)
+            {
+                var cond = (IConditionalOperation)op;
+                return cond.WhenFalse.CanCopy() && cond.WhenFalse.CanCopy();
+            }
+
             return k == OperationKind.ObjectCreation
                 || k == OperationKind.DefaultValue
                 || k == OperationKind.Literal

--- a/src/NonCopyable/NonCopyable/TypeExtensions.cs
+++ b/src/NonCopyable/NonCopyable/TypeExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
@@ -97,5 +99,14 @@ namespace NonCopyable
 
         static bool IsValid(OperationKind kind)
             => kind != OperationKind.None && kind != OperationKind.Invalid;
+
+        public static ISymbol GetSymbol(this IOperation op)
+        {
+            if (op.Kind == OperationKind.LocalReference)
+                return ((ILocalReferenceOperation)op).Local;
+            if (op.Kind == OperationKind.ParameterReference)
+                return ((IParameterReferenceOperation)op).Parameter;
+            throw new NotSupportedException(op.Kind.ToString());
+        }
     }
 }


### PR DESCRIPTION
See individual commits.

`CollectionElementInitializer` action was removed because the new version of Roslyn for C# 9 treats collection initializers as `Add` method invocations, so a separate handler is not needed.